### PR TITLE
Move correct copy to layout

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -69,9 +69,15 @@
         <div class='col-md-9'>
           {{ content }}
 
+
           <h2>Tell Us What You Think!</h2>
 
-          <p>Please take a moment to tell us what you think about this guide on Twitter or the <a href="TBD">Project Name mailing list</a></p>
+          <p>
+            Please take a moment to tell us what you think about this guide
+            <a href="http://twitter.com/clojurewerkz">on Twitter</a>
+            or the
+            <a href="https://groups.google.com/forum/#!forum/clojure-mqtt">Clojure MQTT mailing list</a>
+          </p>
 
           <p>Let us know what was unclear or what has not been covered. Maybe you do not like the guide style or grammar or discover spelling mistakes. Reader feedback is key to making the documentation better.</p>
 

--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -492,11 +492,3 @@ We recommend that you read the following guides first, if possible, in this orde
 TBD
 
 
-## Tell Us What You Think!
-
-Please take a moment to tell us what you think about this guide [on
-Twitter](http://twitter.com/clojurewerkz) or the [Clojure MQTT mailing list](https://groups.google.com/forum/#!forum/clojure-mqtt).
-
-Let us know what was unclear or what has not been covered. Maybe you
-do not like the guide style or grammar or discover spelling
-mistakes. Reader feedback is key to making the documentation better.


### PR DESCRIPTION
Unlinked text was in layout..
Linked text was in article.

Should be all fixed now!
